### PR TITLE
feat(arc): Add Actions Runner Controller module and custom runner image

### DIFF
--- a/.github/workflows/build-arc-runner.yml
+++ b/.github/workflows/build-arc-runner.yml
@@ -1,0 +1,48 @@
+name: Build ARC Runner Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "applications/harvester/config/arc-runner/Dockerfile"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/arc-runner-infersec
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: applications/harvester/config/arc-runner/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/applications/harvester/config/arc-runner/Dockerfile
+++ b/applications/harvester/config/arc-runner/Dockerfile
@@ -1,0 +1,47 @@
+FROM summerwind/actions-runner-dind:latest
+
+USER root
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update \
+    && apt-get install -y \
+        libnss3 \
+        libnspr4 \
+        libatk1.0-0 \
+        libatk-bridge2.0-0 \
+        libcups2 \
+        libdrm2 \
+        libxkbcommon0 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxrandr2 \
+        libgbm1 \
+        libpango-1.0-0 \
+        libcairo2 \
+        libasound2 \
+        libatspi2.0-0 \
+        libwayland-client0 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN DOCKER_COMPOSE_VERSION="2.36.1" \
+    && mkdir -p /usr/local/lib/docker/cli-plugins \
+    && curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64" \
+        -o /usr/local/lib/docker/cli-plugins/docker-compose \
+    && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+
+RUN LLAMA_VERSION="b9354" \
+    && curl -fSL -o /tmp/llama-cpp.tar.gz \
+        https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_VERSION}/llama-${LLAMA_VERSION}-bin-ubuntu-x64.tar.gz \
+    && mkdir -p /opt/llama.cpp \
+    && tar -xzf /tmp/llama-cpp.tar.gz -C /opt/llama.cpp \
+    && ln -sf /opt/llama.cpp/llama-${LLAMA_VERSION}/llama-server /usr/local/bin/llama-server \
+    && rm -f /tmp/llama-cpp.tar.gz
+
+USER runner

--- a/applications/harvester/init_versions.tf
+++ b/applications/harvester/init_versions.tf
@@ -185,5 +185,9 @@ locals {
       uri = "keglin/pinchflat"
       tag = "dev"
     }
+    arc_runner = {
+      uri = "ghcr.io/perry-mitchell/arc-runner-infersec"
+      tag = "latest"
+    }
   }
 }

--- a/applications/harvester/init_versions.tf
+++ b/applications/harvester/init_versions.tf
@@ -186,7 +186,7 @@ locals {
       tag = "dev"
     }
     arc_runner = {
-      uri = "ghcr.io/perry-mitchell/arc-runner-infersec"
+      uri = "ghcr.io/perry-mitchell/homelab-infra/arc-runner-infersec"
       tag = "latest"
     }
   }

--- a/applications/harvester/providers.tf
+++ b/applications/harvester/providers.tf
@@ -5,13 +5,13 @@ provider "harvester" {
 provider "helm" {
   kubernetes {
     config_path = "./kube.config"
-    # config_context = "local"
-    # insecure       = true
   }
+}
+
+provider "kubectl" {
+  config_path = "./kube.config"
 }
 
 provider "kubernetes" {
   config_path = "./kube.config"
-  # config_context = "local"
-  # insecure       = true
 }

--- a/applications/harvester/system_arc.tf
+++ b/applications/harvester/system_arc.tf
@@ -1,0 +1,9 @@
+module "arc" {
+  source = "../../modules-harvester/actions-runner-controller"
+
+  github_pat              = var.arc_github_pat
+  kubeconfig_path         = "./kube.config"
+  longhorn_storage_class  = var.longhorn_storage_class
+  repository              = "perry-mitchell/infersec"
+  runner_image            = local.images.arc_runner
+}

--- a/applications/harvester/system_arc.tf
+++ b/applications/harvester/system_arc.tf
@@ -4,6 +4,6 @@ module "arc" {
   github_pat              = var.arc_github_pat
   kubeconfig_path         = "./kube.config"
   longhorn_storage_class  = var.longhorn_storage_class
-  repository              = "perry-mitchell/infersec"
+  repository              = var.arc_repository
   runner_image            = local.images.arc_runner
 }

--- a/applications/harvester/terraform.tf
+++ b/applications/harvester/terraform.tf
@@ -34,6 +34,10 @@ terraform {
       source  = "loafoe/htpasswd"
       version = "~> 1.0"
     }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
+    }
     kubernetes = {
       source  = "opentofu/kubernetes"
       version = "2.33.0"

--- a/applications/harvester/variables.tf
+++ b/applications/harvester/variables.tf
@@ -12,6 +12,11 @@ variable "arc_github_pat" {
   type        = string
 }
 
+variable "arc_repository" {
+  description = "GitHub repository for ARC runners to target (owner/repo)"
+  type        = string
+}
+
 variable "cluster_name" {
   default = "torrens"
   type    = string

--- a/applications/harvester/variables.tf
+++ b/applications/harvester/variables.tf
@@ -6,6 +6,12 @@ variable "adventurelog_django_admin" {
   })
 }
 
+variable "arc_github_pat" {
+  description = "GitHub Personal Access Token for ARC runner authentication"
+  sensitive   = true
+  type        = string
+}
+
 variable "cluster_name" {
   default = "torrens"
   type    = string

--- a/modules-harvester/actions-runner-controller/main.tf
+++ b/modules-harvester/actions-runner-controller/main.tf
@@ -1,0 +1,137 @@
+resource "kubernetes_namespace" "arc_system" {
+  metadata {
+    name = "arc-system"
+  }
+}
+
+resource "kubernetes_namespace" "arc_runners" {
+  metadata {
+    name = var.runner_namespace
+  }
+}
+
+resource "kubernetes_secret" "github_pat" {
+  metadata {
+    name      = "arc-github-pat"
+    namespace = resource.kubernetes_namespace.arc_system.metadata[0].name
+  }
+
+  data = {
+    github_token = var.github_pat
+  }
+}
+
+resource "helm_release" "arc" {
+  name       = "actions-runner-controller"
+  namespace  = resource.kubernetes_namespace.arc_system.metadata[0].name
+  repository = "https://actions-runner-controller.github.io/actions-runner-controller"
+  chart      = "actions-runner-controller"
+  version    = "0.23.3"
+  wait       = true
+
+  set {
+    name  = "authSecret.create"
+    value = "false"
+  }
+
+  set {
+    name  = "authSecret.name"
+    value = kubernetes_secret.github_pat.metadata[0].name
+  }
+}
+
+resource "kubernetes_persistent_volume_claim" "npm_cache" {
+  metadata {
+    name      = "runner-npm-cache"
+    namespace = var.runner_namespace
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        storage = var.npm_cache_storage
+      }
+    }
+    storage_class_name = var.longhorn_storage_class
+  }
+
+  depends_on = [resource.kubernetes_namespace.arc_runners]
+}
+
+resource "kubernetes_persistent_volume_claim" "general_cache" {
+  metadata {
+    name      = "runner-general-cache"
+    namespace = var.runner_namespace
+  }
+
+  spec {
+    access_modes = ["ReadWriteOnce"]
+    resources {
+      requests = {
+        storage = var.general_cache_storage
+      }
+    }
+    storage_class_name = var.longhorn_storage_class
+  }
+
+  depends_on = [resource.kubernetes_namespace.arc_runners]
+}
+
+resource "kubernetes_manifest" "runner_deployment" {
+  manifest = {
+    apiVersion = "actions.summerwind.dev/v1alpha1"
+    kind       = "RunnerDeployment"
+    metadata = {
+      name      = "e2e-runner"
+      namespace = var.runner_namespace
+    }
+    spec = {
+      replicas = var.runner_replicas
+      template = {
+        spec = {
+          repository = var.repository
+          image      = "${var.runner_image.uri}:${var.runner_image.tag}"
+          labels     = var.runner_labels
+          ephemeral  = true
+          dockerEnabled = true
+
+          resources = {
+            requests = {
+              cpu    = var.runner_cpu_request
+              memory = var.runner_memory_request
+            }
+          }
+
+          volumeMounts = [
+            {
+              name      = "npm-cache"
+              mountPath = "/home/runner/.npm"
+            },
+            {
+              name      = "general-cache"
+              mountPath = "/home/runner/.cache"
+            }
+          ]
+
+          volumes = [
+            {
+              name = "npm-cache"
+              persistentVolumeClaim = {
+                claimName = kubernetes_persistent_volume_claim.npm_cache.metadata[0].name
+              }
+            },
+            {
+              name = "general-cache"
+              persistentVolumeClaim = {
+                claimName = kubernetes_persistent_volume_claim.general_cache.metadata[0].name
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+
+  depends_on = [helm_release.arc]
+}

--- a/modules-harvester/actions-runner-controller/main.tf
+++ b/modules-harvester/actions-runner-controller/main.tf
@@ -1,10 +1,10 @@
-resource "kubernetes_namespace" "arc_system" {
+resource "kubernetes_namespace_v1" "arc_system" {
   metadata {
     name = "arc-system"
   }
 }
 
-resource "kubernetes_namespace" "arc_runners" {
+resource "kubernetes_namespace_v1" "arc_runners" {
   metadata {
     name = var.runner_namespace
   }
@@ -13,7 +13,7 @@ resource "kubernetes_namespace" "arc_runners" {
 resource "kubernetes_secret" "github_pat" {
   metadata {
     name      = "arc-github-pat"
-    namespace = resource.kubernetes_namespace.arc_system.metadata[0].name
+    namespace = resource.kubernetes_namespace_v1.arc_system.metadata[0].name
   }
 
   data = {
@@ -23,7 +23,7 @@ resource "kubernetes_secret" "github_pat" {
 
 resource "helm_release" "arc" {
   name       = "actions-runner-controller"
-  namespace  = resource.kubernetes_namespace.arc_system.metadata[0].name
+  namespace  = resource.kubernetes_namespace_v1.arc_system.metadata[0].name
   repository = "https://actions-runner-controller.github.io/actions-runner-controller"
   chart      = "actions-runner-controller"
   version    = "0.23.3"
@@ -56,7 +56,7 @@ resource "kubernetes_persistent_volume_claim" "npm_cache" {
     storage_class_name = var.longhorn_storage_class
   }
 
-  depends_on = [resource.kubernetes_namespace.arc_runners]
+  depends_on = [resource.kubernetes_namespace_v1.arc_runners]
 }
 
 resource "kubernetes_persistent_volume_claim" "general_cache" {
@@ -75,11 +75,11 @@ resource "kubernetes_persistent_volume_claim" "general_cache" {
     storage_class_name = var.longhorn_storage_class
   }
 
-  depends_on = [resource.kubernetes_namespace.arc_runners]
+  depends_on = [resource.kubernetes_namespace_v1.arc_runners]
 }
 
-resource "kubernetes_manifest" "runner_deployment" {
-  manifest = {
+resource "kubectl_manifest" "runner_deployment" {
+  yaml_body = yamlencode({
     apiVersion = "actions.summerwind.dev/v1alpha1"
     kind       = "RunnerDeployment"
     metadata = {
@@ -90,11 +90,11 @@ resource "kubernetes_manifest" "runner_deployment" {
       replicas = var.runner_replicas
       template = {
         spec = {
-          repository = var.repository
-          image      = "${var.runner_image.uri}:${var.runner_image.tag}"
-          labels     = var.runner_labels
-          ephemeral  = true
-          dockerEnabled = true
+          repository     = var.repository
+          image          = "${var.runner_image.uri}:${var.runner_image.tag}"
+          labels         = var.runner_labels
+          ephemeral      = true
+          dockerEnabled  = true
 
           resources = {
             requests = {
@@ -131,7 +131,7 @@ resource "kubernetes_manifest" "runner_deployment" {
         }
       }
     }
-  }
+  })
 
   depends_on = [helm_release.arc]
 }

--- a/modules-harvester/actions-runner-controller/providers.tf
+++ b/modules-harvester/actions-runner-controller/providers.tf
@@ -1,0 +1,9 @@
+provider "helm" {
+  kubernetes {
+    config_path = var.kubeconfig_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kubeconfig_path
+}

--- a/modules-harvester/actions-runner-controller/providers.tf
+++ b/modules-harvester/actions-runner-controller/providers.tf
@@ -1,9 +1,0 @@
-provider "helm" {
-  kubernetes {
-    config_path = var.kubeconfig_path
-  }
-}
-
-provider "kubernetes" {
-  config_path = var.kubeconfig_path
-}

--- a/modules-harvester/actions-runner-controller/variables.tf
+++ b/modules-harvester/actions-runner-controller/variables.tf
@@ -1,0 +1,70 @@
+variable "github_pat" {
+  description = "GitHub Personal Access Token for ARC runner authentication"
+  type        = string
+  sensitive   = true
+}
+
+variable "kubeconfig_path" {
+  description = "Path to kubeconfig file"
+  type        = string
+}
+
+variable "longhorn_storage_class" {
+  description = "Storage class for PVCs"
+  type        = string
+}
+
+variable "repository" {
+  description = "GitHub repository to target (owner/repo)"
+  type        = string
+}
+
+variable "runner_image" {
+  description = "Container image for the runner (uri + tag)"
+  type = object({
+    uri = string
+    tag = string
+  })
+}
+
+variable "runner_labels" {
+  description = "Labels for the runner"
+  type        = list(string)
+  default     = ["e2e-self-hosted"]
+}
+
+variable "runner_namespace" {
+  description = "Namespace for runner pods"
+  type        = string
+  default     = "arc-runners"
+}
+
+variable "runner_replicas" {
+  description = "Number of runner replicas"
+  type        = number
+  default     = 1
+}
+
+variable "runner_cpu_request" {
+  description = "CPU request per runner pod"
+  type        = string
+  default     = "4"
+}
+
+variable "runner_memory_request" {
+  description = "Memory request per runner pod"
+  type        = string
+  default     = "12Gi"
+}
+
+variable "npm_cache_storage" {
+  description = "Storage request for npm cache PVC"
+  type        = string
+  default     = "10Gi"
+}
+
+variable "general_cache_storage" {
+  description = "Storage request for general cache PVC (Playwright, llama.cpp)"
+  type        = string
+  default     = "20Gi"
+}

--- a/modules-harvester/actions-runner-controller/versions.tf
+++ b/modules-harvester/actions-runner-controller/versions.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    helm = {
+      source  = "opentofu/helm"
+      version = ">= 2.16.0"
+    }
+    kubectl = {
+      source  = "alekc/kubectl"
+      version = ">= 2.0"
+    }
+    kubernetes = {
+      source  = "opentofu/kubernetes"
+      version = ">= 2.33.0"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Provisions ARC (Actions Runner Controller) on the k3s cluster for self-hosted GitHub Actions runners, used by the Infersec E2E test pipeline.

## Changes

### New module: `modules-harvester/actions-runner-controller/`
- Helm release for `actions-runner-controller` chart in `arc-system` namespace
- GitHub PAT authentication via Kubernetes secret
- `RunnerDeployment` in `arc-runners` namespace targeting `perry-mitchell/infersec`
- Runner labels: `e2e-self-hosted`
- Ephemeral pods with DinD enabled
- PVCs for persistent caches:
  - `/home/runner/.npm` (npm cache)
  - `/home/runner/.cache` (Playwright browsers, llama.cpp binary)
- Resource requests: 4 CPU / 12Gi RAM

### Custom runner image
- `applications/harvester/config/arc-runner/Dockerfile`
- Based on `summerwind/actions-runner-dind`
- Pre-baked with: Node.js 24, Playwright system deps, Docker Compose plugin, llama.cpp b9354 binary

### Wiring
- `system_arc.tf` — Wires ARC module into harvester stack
- `variables.tf` — Added `arc_github_pat` sensitive variable
- `init_versions.tf` — Added `arc_runner` image reference

## Related
- Infersec PR for parallel E2E orchestration and workflow changes