### PR TITLE
feat(arc): Add gha-runner-scale-set ARC module for infersec CI

### DIFF
--- a/.github/workflows/build-arc-runner.yml
+++ b/.github/workflows/build-arc-runner.yml
@@ -1,0 +1,52 @@
+name: Build ARC Runner Image
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "applications/harvester/config/arc-runner/Dockerfile"
+      - ".github/workflows/build-arc-runner.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/arc-runner-infersec
+  # Bump alongside the tag pinned in applications/harvester/init_versions.tf
+  IMAGE_VERSION: "1.0.0"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=${{ env.IMAGE_VERSION }}
+            type=raw,value=latest
+            type=sha,prefix=
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: applications/harvester/config/arc-runner/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/applications/harvester/config/arc-runner/Dockerfile
+++ b/applications/harvester/config/arc-runner/Dockerfile
@@ -1,0 +1,58 @@
+# Custom ARC runner image for infersec E2E jobs.
+# Base is the official runner image used by gha-runner-scale-set with
+# containerMode=dind (the Docker daemon runs as a sidecar; this image only
+# needs the docker CLI + compose plugin to talk to it).
+FROM ghcr.io/actions/actions-runner:2.334.0
+
+USER root
+
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
+    && apt-get install -y nodejs \
+    && npm install -g npm@latest \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Playwright / headless browser dependencies (Ubuntu 24.04 package names)
+RUN apt-get update \
+    && apt-get install -y \
+        libnss3 \
+        libnspr4 \
+        libatk1.0-0t64 \
+        libatk-bridge2.0-0t64 \
+        libcups2t64 \
+        libdrm2 \
+        libxkbcommon0 \
+        libxcomposite1 \
+        libxdamage1 \
+        libxfixes3 \
+        libxrandr2 \
+        libgbm1 \
+        libpango-1.0-0 \
+        libcairo2 \
+        libglib2.0-0t64 \
+        libasound2t64 \
+        libatspi2.0-0t64 \
+        libwayland-client0 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Docker CLI + compose plugin (daemon is provided by the dind sidecar)
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc \
+    && chmod a+r /etc/apt/keyrings/docker.asc \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# llama.cpp for inference E2E tests (kept in sync with infersec CI)
+RUN LLAMA_VERSION="b9354" \
+    && curl -fSL -o /tmp/llama-cpp.tar.gz \
+        https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_VERSION}/llama-${LLAMA_VERSION}-bin-ubuntu-x64.tar.gz \
+    && mkdir -p /opt/llama.cpp \
+    && tar -xzf /tmp/llama-cpp.tar.gz -C /opt/llama.cpp \
+    && ln -sf /opt/llama.cpp/llama-${LLAMA_VERSION}/llama-server /usr/local/bin/llama-server \
+    && rm -f /tmp/llama-cpp.tar.gz
+
+USER runner

--- a/applications/harvester/docs/ARC.md
+++ b/applications/harvester/docs/ARC.md
@@ -1,0 +1,76 @@
+# ARC (Actions Runner Controller) — infersec CI
+
+Runs GitHub Actions workflows from `perry-mitchell/infersec` on ephemeral
+runners inside the Harvester cluster.
+
+## Layout
+
+| Component | Location |
+|---|---|
+| ARC controller (`gha-runner-scale-set-controller`) | `arc-system` namespace |
+| Runner scale set (`infersec-e2e`) | `infersec-ci` namespace |
+| Runner pods (dind, ephemeral) | `infersec-ci` namespace |
+| Custom runner image | `ghcr.io/perry-mitchell/homelab-infra/arc-runner-infersec` |
+
+The controller chart creates no GitHub credentials of its own; the scale set
+reads the pre-created `arc-github-pat` secret (`github_token` key) in
+`infersec-ci`.
+
+## How it works
+
+ * Workflows targeting `runs-on: [self-hosted, e2e-self-hosted]` are picked up
+   by the scale set listener (labels are set via `scaleSetLabels`).
+ * The scale set spawns ephemeral runner pods (`containerMode: dind`) up to
+   `max_runners`. Each pod has its own Docker daemon sidecar, so parallel jobs
+   from multiple branches are fully isolated from each other — every branch's
+   E2E run gets its own docker engine, network and volumes.
+ * Inside a job, the infersec test stack runs via docker compose (unique
+   project name + `PORT_*` port blocks per suite, see
+   `test-e2e-parallel.sh` in the infersec repo). Everything is destroyed with
+   the runner pod when the job finishes.
+
+## Setup / updates
+
+1. Create a fine-grained PAT on `perry-mitchell/infersec` with **Actions: Read
+   and write** and **Administration: Read and write** (needed to register
+   runners). Put it in `terraform.tfvars` (git ignored):
+   ```tfvars
+   arc_github_pat = "github_pat_..."
+   ```
+2. Ensure the runner image exists in GHCR. It is built by the
+   `Build ARC Runner Image` workflow — dispatch it manually after merging
+   changes to the Dockerfile (workflow_dispatch only works from `main`).
+3. Run `tofu plan` / `tofu apply` from `applications/harvester`.
+
+### Image versioning convention
+
+The runner image is referenced from `init_versions.tf`
+(`images.arc_runner`). Bump the tag there **and** `IMAGE_VERSION` in the
+build workflow whenever the Dockerfile changes, then rebuild.
+
+## Knobs
+
+ * `max_runners` / `min_runners` — autoscaling bounds (defaults: 2 / 0).
+ * `runner_cpu_request` / `runner_memory_request` — per runner pod
+   (defaults: `4` CPU / `12Gi` — sized for parallel E2E suites with
+   llama.cpp). Peak cluster usage ≈ max_runners × requests.
+ * `runner_labels` — labels for `runs-on` targeting.
+
+## Troubleshooting
+
+```sh
+# Controller logs
+kubectl -n arc-system logs deploy/gha-runner-scale-set-controller
+
+# Listener + ephemeral runner pods
+kubectl -n infersec-ci get pods
+kubectl -n infersec-ci logs <runner-pod> -c runner
+
+# Registered runners / scale set state
+kubectl get runnerscalesets -A
+kubectl -n infersec-ci get ephemeralrunnersets
+```
+
+If jobs queue forever: check the listener pod logs (usually a PAT permission
+problem), and confirm the workflow uses both `self-hosted` and
+`e2e-self-hosted` labels.

--- a/applications/harvester/docs/ARC.md
+++ b/applications/harvester/docs/ARC.md
@@ -31,7 +31,7 @@ reads the pre-created `arc-github-pat` secret (`github_token` key) in
 
 ## Setup / updates
 
-1. Create a fine-grained PAT on `perry-mitchell/infersec` with **Actions: Read
+1. Create a fine-grained PAT on `<infersec-repo>` with **Actions: Read
    and write** and **Administration: Read and write** (needed to register
    runners). Put it in `terraform.tfvars` (git ignored):
    ```tfvars

--- a/applications/harvester/init_versions.tf
+++ b/applications/harvester/init_versions.tf
@@ -221,6 +221,11 @@ locals {
       uri = "rg.nl-ams.scw.cloud/infersec-public/infersec-production/selfhosted"
       tag = "1.90.5"
     }
+    # Custom image built by .github/workflows/build-arc-runner.yml (bump tag when the Dockerfile changes)
+    arc_runner = {
+      uri = "ghcr.io/perry-mitchell/homelab-infra/arc-runner-infersec"
+      tag = "1.0.0"
+    }
     versity = {
       uri = "versity/versitygw"
       tag = "v1.7.0"

--- a/applications/harvester/system_arc.tf
+++ b/applications/harvester/system_arc.tf
@@ -1,0 +1,7 @@
+module "arc" {
+  source = "../../modules-harvester/actions-runner-controller"
+
+  github_pat   = var.arc_github_pat
+  repository   = var.arc_repository
+  runner_image = local.images.arc_runner
+}

--- a/applications/harvester/variables.tf
+++ b/applications/harvester/variables.tf
@@ -15,7 +15,6 @@ variable "arc_github_pat" {
 variable "arc_repository" {
   description = "GitHub repository that ARC registers runners against (owner/repo)"
   type        = string
-  default     = "perry-mitchell/infersec"
 }
 
 variable "cluster_name" {

--- a/applications/harvester/variables.tf
+++ b/applications/harvester/variables.tf
@@ -6,6 +6,18 @@ variable "adventurelog_django_admin" {
   })
 }
 
+variable "arc_github_pat" {
+  description = "GitHub PAT used by ARC to register ephemeral runners for infersec CI"
+  type        = string
+  sensitive   = true
+}
+
+variable "arc_repository" {
+  description = "GitHub repository that ARC registers runners against (owner/repo)"
+  type        = string
+  default     = "perry-mitchell/infersec"
+}
+
 variable "cluster_name" {
   default = "torrens"
   type    = string

--- a/modules-harvester/actions-runner-controller/main.tf
+++ b/modules-harvester/actions-runner-controller/main.tf
@@ -1,0 +1,84 @@
+resource "kubernetes_namespace_v1" "arc_system" {
+  metadata {
+    name = "arc-system"
+  }
+}
+
+resource "kubernetes_namespace_v1" "runners" {
+  metadata {
+    name = var.runner_namespace
+  }
+}
+
+# Referenced by the scale set via `githubConfigSecret` (pre-defined secret variation)
+resource "kubernetes_secret" "github_pat" {
+  metadata {
+    name      = "arc-github-pat"
+    namespace = kubernetes_namespace_v1.runners.metadata[0].name
+  }
+
+  data = {
+    github_token = var.github_pat
+  }
+}
+
+resource "helm_release" "controller" {
+  name       = "gha-runner-scale-set-controller"
+  namespace  = kubernetes_namespace_v1.arc_system.metadata[0].name
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart      = "gha-runner-scale-set-controller"
+  version    = var.controller_chart_version
+  wait       = true
+}
+
+resource "helm_release" "scale_set" {
+  name       = "infersec-e2e"
+  namespace  = kubernetes_namespace_v1.runners.metadata[0].name
+  repository = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart      = "gha-runner-scale-set"
+  version    = var.scale_set_chart_version
+  wait       = true
+
+  values = [
+    yamlencode({
+      githubConfigUrl    = "https://github.com/${var.repository}"
+      githubConfigSecret = kubernetes_secret.github_pat.metadata[0].name
+
+      scaleSetLabels = var.runner_labels
+      minRunners     = var.min_runners
+      maxRunners     = var.max_runners
+
+      containerMode = {
+        type = "dind"
+      }
+
+      controllerServiceAccount = {
+        namespace = kubernetes_namespace_v1.arc_system.metadata[0].name
+        name      = helm_release.controller.name
+      }
+
+      template = {
+        spec = {
+          containers = [
+            {
+              name    = "runner"
+              image   = "${var.runner_image.uri}:${var.runner_image.tag}"
+              command = ["/home/runner/run.sh"]
+              resources = {
+                requests = {
+                  cpu    = var.runner_cpu_request
+                  memory = var.runner_memory_request
+                }
+              }
+            }
+          ]
+        }
+      }
+    })
+  ]
+
+  depends_on = [
+    helm_release.controller,
+    kubernetes_secret.github_pat,
+  ]
+}

--- a/modules-harvester/actions-runner-controller/variables.tf
+++ b/modules-harvester/actions-runner-controller/variables.tf
@@ -1,0 +1,67 @@
+variable "github_pat" {
+  description = "GitHub Personal Access Token used by the scale set to register runners (needs Actions: read/write on the target repository)"
+  type        = string
+  sensitive   = true
+}
+
+variable "repository" {
+  description = "GitHub repository to register runners against (owner/repo)"
+  type        = string
+  default     = "perry-mitchell/infersec"
+}
+
+variable "runner_image" {
+  description = "Container image for the runner pods (uri + tag)"
+  type = object({
+    uri = string
+    tag = string
+  })
+}
+
+variable "controller_chart_version" {
+  description = "Version of the gha-runner-scale-set-controller chart"
+  type        = string
+  default     = "0.14.2"
+}
+
+variable "scale_set_chart_version" {
+  description = "Version of the gha-runner-scale-set chart"
+  type        = string
+  default     = "0.14.2"
+}
+
+variable "runner_namespace" {
+  description = "Dedicated namespace for runner pods (listener + ephemeral runners)"
+  type        = string
+  default     = "infersec-ci"
+}
+
+variable "runner_labels" {
+  description = "Labels applied to runners in the scale set (used by `runs-on`)"
+  type        = list(string)
+  default     = ["e2e-self-hosted"]
+}
+
+variable "min_runners" {
+  description = "Minimum number of idle runner pods"
+  type        = number
+  default     = 0
+}
+
+variable "max_runners" {
+  description = "Maximum number of concurrent runner pods"
+  type        = number
+  default     = 2
+}
+
+variable "runner_cpu_request" {
+  description = "CPU request per runner pod"
+  type        = string
+  default     = "4"
+}
+
+variable "runner_memory_request" {
+  description = "Memory request per runner pod"
+  type        = string
+  default     = "12Gi"
+}

--- a/modules-harvester/actions-runner-controller/versions.tf
+++ b/modules-harvester/actions-runner-controller/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_providers {
+    helm = {
+      source = "opentofu/helm"
+    }
+    kubernetes = {
+      source = "opentofu/kubernetes"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Revives the ARC integration on current `main`, migrating from the deprecated legacy design (#3) to the current Actions Runner Controller, so select workflows from `<infersec>` (the E2E suite) run on ephemeral runners inside the Harvester cluster.

### What's included

- **New `modules-harvester/actions-runner-controller`** (replaces the legacy v0.23.3 / `RunnerDeployment` / `summerwind` image design — that chart line is deprecated):
  - `gha-runner-scale-set-controller` **0.14.2** (Helm, OCI repo) in `arc-system`
  - Runner scale set `infersec-e2e` (chart **0.14.2**) in a dedicated **`infersec-ci`** namespace
  - Listener autoscaling `minRunners 0` / `maxRunners 2`, labels `e2e-self-hosted`, `containerMode: dind`
  - PAT via pre-created `arc-github-pat` secret (sensitive var `arc_github_pat`, value only in gitignored `terraform.tfvars`)
- **Custom runner image** (`applications/harvester/config/arc-runner/Dockerfile`) rebased onto `ghcr.io/actions/actions-runner:2.334.0` (Ubuntu 24.04): Node 24, Playwright libs (`t64` package set), docker CLI + compose plugin from Docker's apt repo (the official base ships no docker CLI), llama.cpp `b9354`
- **Build workflow**: `Build ARC Runner Image` publishes `arc-runner-infersec` tagged `1.0.0` / `latest` / sha; pinned via `images.arc_runner` in `init_versions.tf`
- **Docs**: `applications/harvester/docs/ARC.md` (PAT scopes, setup order, scaling knobs, troubleshooting)

### Multi-branch isolation

Each queued CI job (from any branch/PR of infersec) gets its own ephemeral dind runner pod in `infersec-ci` — private docker daemon, network and volumes, destroyed with the job. Inside a runner, the parallel orchestrator runs per-suite compose projects on distinct port blocks. Peak usage ≈ `max_runners` × per-pod requests (2 × 4 CPU / 12 Gi by default).

## Post-merge checklist (manual)

1. Dispatch **Build ARC Runner Image** to publish `arc-runner-infersec:1.0.0`
2. Add `arc_github_pat` to `terraform.tfvars` — fine-grained PAT on `<infersec>` with **Actions: R/W** and **Administration: R/W**
3. `tofu plan` / `tofu apply` from `applications/harvester`

## Validation

- `tofu fmt` + `tofu validate` pass (validated in a stateless copy of the tree)
- Chart values verified against the published `gha-runner-scale-set(-controller)` 0.14.2 `values.yaml`

Closes #3 (superseded).